### PR TITLE
Fix uncaught promise in recurrence update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A powerful and comprehensive plugin for to-do repetition/recurrence
 
 
 ## Overview
-This plugin allows to-do's in joplin to be repeated based on the to-do alarm date. When a to-do is checked as complete, the todo alarm date is immediately reset to the next recurrence date, and the to-do is unmarked as completed. 
+This plugin allows to-do's in joplin to be repeated based on the to-do alarm date. When a to-do is checked as complete, the todo alarm date is immediately reset to the next recurrence date, and the to-do is unmarked as completed.
 
 This plugin allows to-dos to be repeated every minute, hour, day, week, month and year, based on the to-do alarm date and time. Weekly to-dos can also recur on specific weekdays (eg Mon-Fri or Sun, Sat and Wendesday, etc.) and monthly to-dos can recur on specific weekdays of the month (eg, the first Sunday, the second Friday, the last Tuesday, etc)
 
@@ -25,7 +25,7 @@ This plugin is in the joplin plugin repository and can be installed from within 
 
 ![recurrence-dialog](docs/recurrence-dialog.png)
 
-3. The interval box determines how often the to-do should repeat (eg, every 2 days, every week, every 4 months, etc.). 
+3. The interval box determines how often the to-do should repeat (eg, every 2 days, every week, every 4 months, etc.).
 
 The interval box specifies which time interval between each to-do repetition. The valid options are minutes, hours, days, weeks, months and years.
 
@@ -35,7 +35,7 @@ The interval number box determines the number of time intervals before a to-do r
 
 ![recurrence-interval-number](docs/recurrence-interval-number.png)
 
-4. If the recurrence interval is set to weeks, the Weekdays box will allow you to select which specific weekday the to-do should repeat on. For example, checking Mondays, Wednesdays and Fridays, means the task will only repeat on those specific days. Setting no weekdays means the to-do will repeat only on the same weekday the original alarm date fell on. 
+4. If the recurrence interval is set to weeks, the Weekdays box will allow you to select which specific weekday the to-do should repeat on. For example, checking Mondays, Wednesdays and Fridays, means the task will only repeat on those specific days. Setting no weekdays means the to-do will repeat only on the same weekday the original alarm date fell on.
 
 ![recurrence-weekdays](docs/recurrence-weekdays.png)
 
@@ -43,11 +43,11 @@ The interval number box determines the number of time intervals before a to-do r
 
 ![recurrence-weekday-of-month](docs/recurrence-weekday-of-month.png)
 
-6. To-dos can be set to repeat forever (default), 
+6. To-dos can be set to repeat forever (default),
 
 ![recurrence-stop-never](docs/recurrence-stop-never.png)
 
-or to stop repeating after a certain number of times, 
+or to stop repeating after a certain number of times,
 
 ![recurrence-stop-number](docs/recurrence-stop-number.png)
 
@@ -55,11 +55,11 @@ or after a specific date
 
 ![recurrence-stop-date](docs/recurrence-stop-date.png)
 
-7. Once the to-do has been configured to specifications, click OK to save the changes. 
+7. Once the to-do has been configured to specifications, click OK to save the changes.
 
 ### Database Updates
 
-The Repeating To-Do plugin maintains a database of each note's repetition settings. Occasionally, this database becomes out of sync with the actual notes and to-dos in joplin. In order to update the database and resynchronise it, just go to the Tools menu then select "Repeating To-dos" -> "Update recurrence database". 
+The Repeating To-Do plugin maintains a database of each note's repetition settings. Occasionally, this database becomes out of sync with the actual notes and to-dos in joplin. In order to update the database and resynchronise it, just go to the Tools menu then select "Repeating To-dos" -> "Update recurrence database".
 
 ## Installation (Development)
 If you wish to contribute to this plugin, you're more than welcome to! To start, create a fork of this repository at https://gitlab.com/beatlink-code/joplin-plugin-repeating-todos.
@@ -67,10 +67,10 @@ If you wish to contribute to this plugin, you're more than welcome to! To start,
 Next, clone this repository to your workstation using git. (the below should be changed to point to your own fork)
 
 ```bash
-git clone git@gitlab.com:beatlink-code/joplin-plugin-repeating-todos.git
+git clone git@github.com:vargab95/Joplin-Repeating-Todos-Plugin.git
 ```
 
-Afterwards, open a terminal in the repository root, and run the following to install dependencies. 
+Afterwards, open a terminal in the repository root, and run the following to install dependencies.
 
 ```bash
 npm install
@@ -86,12 +86,12 @@ npm run dist
 
 The compiled code will be saved to the `/dist` folder. The joplin plugin will be built in the `/publish` folder
 
-Debugging can also be aided by launching joplin in development mode to be used as a testing ground. 
+Debugging can also be aided by launching joplin in development mode to be used as a testing ground.
 
 ```bash
 /path/to/joplin --env dev
 ```
 
-The repeating to-do plugin will need to be added as a development plugin. 
+The repeating to-do plugin will need to be added as a development plugin.
 
 Once you have made your changes, commit, and push your changes to your fork and create a pull request on GitLab

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A powerful and comprehensive plugin for to-do repetition/recurrence
 
 
 ## Overview
-This plugin allows to-do's in joplin to be repeated based on the to-do alarm date. When a to-do is checked as complete, the todo alarm date is immediately reset to the next recurrence date, and the to-do is unmarked as completed. 
+This plugin allows to-do's in joplin to be repeated based on the to-do alarm date. When a to-do is checked as complete, the todo alarm date is immediately reset to the next recurrence date, and the to-do is unmarked as completed.
 
 This plugin allows to-dos to be repeated every minute, hour, day, week, month and year, based on the to-do alarm date and time. Weekly to-dos can also recur on specific weekdays (eg Mon-Fri or Sun, Sat and Wendesday, etc.) and monthly to-dos can recur on specific weekdays of the month (eg, the first Sunday, the second Friday, the last Tuesday, etc)
 
@@ -25,7 +25,7 @@ This plugin is in the joplin plugin repository and can be installed from within 
 
 ![recurrence-dialog](docs/recurrence-dialog.png)
 
-3. The interval box determines how often the to-do should repeat (eg, every 2 days, every week, every 4 months, etc.). 
+3. The interval box determines how often the to-do should repeat (eg, every 2 days, every week, every 4 months, etc.).
 
 The interval box specifies which time interval between each to-do repetition. The valid options are minutes, hours, days, weeks, months and years.
 
@@ -35,7 +35,7 @@ The interval number box determines the number of time intervals before a to-do r
 
 ![recurrence-interval-number](docs/recurrence-interval-number.png)
 
-4. If the recurrence interval is set to weeks, the Weekdays box will allow you to select which specific weekday the to-do should repeat on. For example, checking Mondays, Wednesdays and Fridays, means the task will only repeat on those specific days. Setting no weekdays means the to-do will repeat only on the same weekday the original alarm date fell on. 
+4. If the recurrence interval is set to weeks, the Weekdays box will allow you to select which specific weekday the to-do should repeat on. For example, checking Mondays, Wednesdays and Fridays, means the task will only repeat on those specific days. Setting no weekdays means the to-do will repeat only on the same weekday the original alarm date fell on.
 
 ![recurrence-weekdays](docs/recurrence-weekdays.png)
 
@@ -43,11 +43,11 @@ The interval number box determines the number of time intervals before a to-do r
 
 ![recurrence-weekday-of-month](docs/recurrence-weekday-of-month.png)
 
-6. To-dos can be set to repeat forever (default), 
+6. To-dos can be set to repeat forever (default),
 
 ![recurrence-stop-never](docs/recurrence-stop-never.png)
 
-or to stop repeating after a certain number of times, 
+or to stop repeating after a certain number of times,
 
 ![recurrence-stop-number](docs/recurrence-stop-number.png)
 
@@ -55,22 +55,23 @@ or after a specific date
 
 ![recurrence-stop-date](docs/recurrence-stop-date.png)
 
-7. Once the to-do has been configured to specifications, click OK to save the changes. 
+7. Once the to-do has been configured to specifications, click OK to save the changes.
 
 ### Database Updates
 
-The Repeating To-Do plugin maintains a database of each note's repetition settings. Occasionally, this database becomes out of sync with the actual notes and to-dos in joplin. In order to update the database and resynchronise it, just go to the Tools menu then select "Repeating To-dos" -> "Update recurrence database". 
+The Repeating To-Do plugin maintains a database of each note's repetition settings. Occasionally, this database becomes out of sync with the actual notes and to-dos in joplin. In order to update the database and resynchronise it, just go to the Tools menu then select "Repeating To-dos" -> "Update recurrence database".
 
-## Installation (Development)
-If you wish to contribute to this plugin, you're more than welcome to! To start, create a fork of this repository at https://gitlab.com/beatlink-code/joplin-plugin-repeating-todos.
+## Installation (Development) If you wish to contribute to this plugin, you're
+more than welcome to! To start, create a fork of this repository at
+https://github.com/BeatLink/Joplin-Repeating-Todos-Plugin.
 
 Next, clone this repository to your workstation using git. (the below should be changed to point to your own fork)
 
 ```bash
-git clone git@gitlab.com:beatlink-code/joplin-plugin-repeating-todos.git
+git clone git@github.com:BeatLink/Joplin-Repeating-Todos-Plugin.git
 ```
 
-Afterwards, open a terminal in the repository root, and run the following to install dependencies. 
+Afterwards, open a terminal in the repository root, and run the following to install dependencies.
 
 ```bash
 npm install
@@ -86,12 +87,13 @@ npm run dist
 
 The compiled code will be saved to the `/dist` folder. The joplin plugin will be built in the `/publish` folder
 
-Debugging can also be aided by launching joplin in development mode to be used as a testing ground. 
+Debugging can also be aided by launching joplin in development mode to be used as a testing ground.
 
 ```bash
 /path/to/joplin --env dev
 ```
 
-The repeating to-do plugin will need to be added as a development plugin. 
+The repeating to-do plugin will need to be added as a development plugin.
 
-Once you have made your changes, commit, and push your changes to your fork and create a pull request on GitLab
+Once you have made your changes, commit, and push your changes to your fork and
+create a pull request on Github.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A powerful and comprehensive plugin for to-do repetition/recurrence
 
 
 ## Overview
-This plugin allows to-do's in joplin to be repeated based on the to-do alarm date. When a to-do is checked as complete, the todo alarm date is immediately reset to the next recurrence date, and the to-do is unmarked as completed.
+This plugin allows to-do's in joplin to be repeated based on the to-do alarm date. When a to-do is checked as complete, the todo alarm date is immediately reset to the next recurrence date, and the to-do is unmarked as completed. 
 
 This plugin allows to-dos to be repeated every minute, hour, day, week, month and year, based on the to-do alarm date and time. Weekly to-dos can also recur on specific weekdays (eg Mon-Fri or Sun, Sat and Wendesday, etc.) and monthly to-dos can recur on specific weekdays of the month (eg, the first Sunday, the second Friday, the last Tuesday, etc)
 
@@ -25,7 +25,7 @@ This plugin is in the joplin plugin repository and can be installed from within 
 
 ![recurrence-dialog](docs/recurrence-dialog.png)
 
-3. The interval box determines how often the to-do should repeat (eg, every 2 days, every week, every 4 months, etc.).
+3. The interval box determines how often the to-do should repeat (eg, every 2 days, every week, every 4 months, etc.). 
 
 The interval box specifies which time interval between each to-do repetition. The valid options are minutes, hours, days, weeks, months and years.
 
@@ -35,7 +35,7 @@ The interval number box determines the number of time intervals before a to-do r
 
 ![recurrence-interval-number](docs/recurrence-interval-number.png)
 
-4. If the recurrence interval is set to weeks, the Weekdays box will allow you to select which specific weekday the to-do should repeat on. For example, checking Mondays, Wednesdays and Fridays, means the task will only repeat on those specific days. Setting no weekdays means the to-do will repeat only on the same weekday the original alarm date fell on.
+4. If the recurrence interval is set to weeks, the Weekdays box will allow you to select which specific weekday the to-do should repeat on. For example, checking Mondays, Wednesdays and Fridays, means the task will only repeat on those specific days. Setting no weekdays means the to-do will repeat only on the same weekday the original alarm date fell on. 
 
 ![recurrence-weekdays](docs/recurrence-weekdays.png)
 
@@ -43,11 +43,11 @@ The interval number box determines the number of time intervals before a to-do r
 
 ![recurrence-weekday-of-month](docs/recurrence-weekday-of-month.png)
 
-6. To-dos can be set to repeat forever (default),
+6. To-dos can be set to repeat forever (default), 
 
 ![recurrence-stop-never](docs/recurrence-stop-never.png)
 
-or to stop repeating after a certain number of times,
+or to stop repeating after a certain number of times, 
 
 ![recurrence-stop-number](docs/recurrence-stop-number.png)
 
@@ -55,11 +55,11 @@ or after a specific date
 
 ![recurrence-stop-date](docs/recurrence-stop-date.png)
 
-7. Once the to-do has been configured to specifications, click OK to save the changes.
+7. Once the to-do has been configured to specifications, click OK to save the changes. 
 
 ### Database Updates
 
-The Repeating To-Do plugin maintains a database of each note's repetition settings. Occasionally, this database becomes out of sync with the actual notes and to-dos in joplin. In order to update the database and resynchronise it, just go to the Tools menu then select "Repeating To-dos" -> "Update recurrence database".
+The Repeating To-Do plugin maintains a database of each note's repetition settings. Occasionally, this database becomes out of sync with the actual notes and to-dos in joplin. In order to update the database and resynchronise it, just go to the Tools menu then select "Repeating To-dos" -> "Update recurrence database". 
 
 ## Installation (Development)
 If you wish to contribute to this plugin, you're more than welcome to! To start, create a fork of this repository at https://gitlab.com/beatlink-code/joplin-plugin-repeating-todos.
@@ -67,10 +67,10 @@ If you wish to contribute to this plugin, you're more than welcome to! To start,
 Next, clone this repository to your workstation using git. (the below should be changed to point to your own fork)
 
 ```bash
-git clone git@github.com:vargab95/Joplin-Repeating-Todos-Plugin.git
+git clone git@gitlab.com:beatlink-code/joplin-plugin-repeating-todos.git
 ```
 
-Afterwards, open a terminal in the repository root, and run the following to install dependencies.
+Afterwards, open a terminal in the repository root, and run the following to install dependencies. 
 
 ```bash
 npm install
@@ -86,12 +86,12 @@ npm run dist
 
 The compiled code will be saved to the `/dist` folder. The joplin plugin will be built in the `/publish` folder
 
-Debugging can also be aided by launching joplin in development mode to be used as a testing ground.
+Debugging can also be aided by launching joplin in development mode to be used as a testing ground. 
 
 ```bash
 /path/to/joplin --env dev
 ```
 
-The repeating to-do plugin will need to be added as a development plugin.
+The repeating to-do plugin will need to be added as a development plugin. 
 
 Once you have made your changes, commit, and push your changes to your fork and create a pull request on GitLab

--- a/src/model/recurrence.ts
+++ b/src/model/recurrence.ts
@@ -161,7 +161,8 @@ export class Recurrence {
             while (newDate < after) {
                 newDate = this.getNextDate(newDate)
                 console.log(`newDate ${newDate}`)
-            }    
+            }
+            return newDate;
         }
     }
 
@@ -209,7 +210,7 @@ export class Recurrence {
         if (this.weekSaturday == true) {weekArray.push(6)}              // If saturday enabled add 6 to array
         return weekArray                                                // Return the array
 
-    } 
+    }
 
     /* getMonthWeekday ********************************************************************************************************************
         Gets the nth weekday of the month of the given date according to the monthOrdinal and monthWeekday variables
@@ -217,7 +218,7 @@ export class Recurrence {
         Next it then gets the nth weekday of the list, determined by the monthOrdinal, eg. the second thursday of the month
     */
     private getMonthWeekday(date: Date){
-        var ordinal = this.monthOrdinalStrings.indexOf(this.monthOrdinal)      // Get the month ordinal as integer    
+        var ordinal = this.monthOrdinalStrings.indexOf(this.monthOrdinal)      // Get the month ordinal as integer
         var weekday = this.weekdayStrings.indexOf(this.monthWeekday)      // Get the month weekday as integer
         var weekdays = [];                                              // Create array for matching weekdays
         var startDate = new Date(date)                                  // Create a new date for manipulation


### PR DESCRIPTION
The getNextDateAfter function did not return with the calculated new date which resulted in accessing the getTime function of undefined which resulted in an uncaught promise, blocking the recurrence update.